### PR TITLE
Fix/laf 007 repeated packets

### DIFF
--- a/analyzers/rolaguard_base_analyzer/BaseAnalyzerMain.py
+++ b/analyzers/rolaguard_base_analyzer/BaseAnalyzerMain.py
@@ -5,6 +5,8 @@ from db.Models import DevNonce, Gateway, Device, DeviceSession, GatewayToDevice,
 from utils import emit_alert
 from analyzers.rolaguard_base_analyzer.ResourceMeter import ResourceMeter
 from analyzers.rolaguard_base_analyzer.DeviceIdentifier import DeviceIdentifier
+from analyzers.rolaguard_base_analyzer.CheckDuplicatedSession import CheckDuplicatedSession
+
 from utils import Chronometer
 
 
@@ -15,6 +17,7 @@ jr_counters = defaultdict(lambda: 0)
 
 resource_meter = ResourceMeter()
 device_identifier = DeviceIdentifier()
+check_duplicated_session = CheckDuplicatedSession()
 
 chrono = Chronometer(report_every=1000)
 
@@ -199,29 +202,16 @@ def process_packet(packet, policy):
                                                     "Packet id %d"%(packet.id))
 
                     device_session.reset_counter += 1
-        
-        elif ( # Conditions to emit a LAF-007
-            # The policy is enabled
-            policy.is_enabled("LAF-007") and
-            # Have the last uplink mic for this device session
-            device_session.id in last_uplink_mic and
-            (
-                # Received a counter smaller than the expected
-                (packet.f_count < device_session.up_link_counter) or
-                # Or equal but with a different mic
-                ((packet.f_count == device_session.up_link_counter) and (last_uplink_mic[device_session.id] != packet.mic))
-            ) and
-            # To avoid errors when the counter overflows
-            (packet.f_count > 5 or device_session.up_link_counter < 65530) and
-            # Disable this alert for TTN collectors
-            not DataCollector.get(packet.data_collector_id).is_ttn()
-            ) :
-                emit_alert("LAF-007", packet, device=device, device_session=device_session, gateway=gateway,
-                            counter=device_session.up_link_counter,
-                            new_counter=packet.f_count,
-                            prev_packet_id=device_session.last_packet_id)
-
         last_uplink_mic[device_session.id]= packet.mic
+
+    check_duplicated_session(
+        packet=packet,
+        device_session=device_session,
+        device=device,
+        gateway=gateway,
+        policy=policy
+        )
+
 
     chrono.stop()
 

--- a/analyzers/rolaguard_base_analyzer/BaseAnalyzerMain.py
+++ b/analyzers/rolaguard_base_analyzer/BaseAnalyzerMain.py
@@ -237,8 +237,7 @@ def process_packet(packet, policy):
     ## Check alert LAF-100
     if (
         device and device.max_rssi is not None and \
-        device.max_rssi < -120
-        # device.max_rssi < policy.get_parameters("LAF-100")["minimum_rssi"]
+        device.max_rssi < policy.get_parameters("LAF-100")["minimum_rssi"]
     ):
         emit_alert(
             "LAF-100", packet,
@@ -252,15 +251,14 @@ def process_packet(packet, policy):
     if (
         device and \
         device.activity_freq is not None and device.npackets_lost is not None and \
-        device.npackets_lost > 20
-        # device.npackets_lost > policy.get_parameters("LAF-101")["max_lost_packets"]
+        device.npackets_lost > policy.get_parameters("LAF-101")["max_lost_packets"]
     ):
         emit_alert(
             "LAF-101", packet,
             device=device,
             device_session=device_session,
             gateway=gateway,
-            packets_lost=count_diff
+            packets_lost=device.npackets_lost
             )
     chrono.stop("total")
     chrono.lap()

--- a/analyzers/rolaguard_base_analyzer/CheckDuplicatedSession.py
+++ b/analyzers/rolaguard_base_analyzer/CheckDuplicatedSession.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+import logging as log
+
+from utils.AlertGenerator import emit_alert
+from db.Models import DataCollector
+
+
+
+class CheckDuplicatedSession():
+    def __init__(self):
+        self.last_packet = defaultdict(lambda: {})
+
+    def __call__(self, packet, device_session, device, gateway, policy):
+        if (
+            packet.m_type not in ["UnconfirmedDataUp", "ConfirmedDataUp"] or
+            device_session is None or
+            gateway is None or
+            packet.f_count is None
+        ): return # Do nothing, ignore the packet
+
+        # Used to identify a "connection" to check. Here for connection we are 
+        # talking about the flow of packets between a gateway and a device in
+        # in the context of a stablished device_session.
+        lpacket_uid = (device_session.id, gateway.id)
+
+        if (
+            lpacket_uid in self.last_packet and
+            policy.is_enabled("LAF-007") and
+            self.is_session_duplicated(
+                counter = packet.f_count,
+                prev_counter = self.last_packet[lpacket_uid]["f_count"],
+                mic = packet.mic,
+                prev_mic = self.last_packet[lpacket_uid]["mic"]
+                ) and
+            not DataCollector.get(packet.data_collector_id).is_ttn()
+            ) :
+                emit_alert(
+                    "LAF-007", packet, device=device,
+                    device_session=device_session, gateway=gateway,
+                    counter=device_session.up_link_counter,
+                    new_counter=packet.f_count,
+                    prev_packet_id=device_session.last_packet_id
+                    )
+
+        # For each "connection" (see definition in previous comment), we save
+        # the counter and mic.
+        self.last_packet[lpacket_uid] = {
+            'f_count' : packet.f_count,
+            'mic' : packet.mic
+        }
+
+
+    def is_session_duplicated(self, counter, prev_counter, mic, prev_mic):
+        """
+        Check if the counter and mic of two consecutive packets indicates the 
+        possible existance of a duplicated session.
+        """
+        if (
+            (counter > 16 or prev_counter < 65520) and \
+                    ((counter < prev_counter) or \
+                    ((counter == prev_counter) and (mic != prev_mic)))
+        ): return True
+        else: return False


### PR DESCRIPTION
The algorithm hasn't big changes with respect of the original code, but it was moved to another file. The only modification to the algorithm is that now each f_count and mic is registered by device_session_id and gateway_id, while before it was registered only by device_session_id.